### PR TITLE
turbolinksによるアニメーションのちらつき対処

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -4,7 +4,7 @@
 // that code so it'll be compiled.
 
 require("@rails/ujs").start()
-require("turbolinks").start()
+// require("turbolinks").start()
 require("@rails/activestorage").start()
 require("channels")
 require("jquery")

--- a/app/javascript/packs/click_next.js
+++ b/app/javascript/packs/click_next.js
@@ -2,7 +2,7 @@
 
 import {typing1} from './typing.js';
 
-$(document).on('turbolinks:load', function() {
+$(function() {
   let num = 0;
 $(".next2").click(function(){
   $(this).data("click", ++num)

--- a/app/javascript/packs/display_none.js
+++ b/app/javascript/packs/display_none.js
@@ -1,4 +1,4 @@
-document.addEventListener("turbolinks:load", function(){
+document.addEventListener("DOMContentLoaded", function(){
   if(document.URL.match(/results/)){
     const count = 1600;
     const disp1 ="document.getElementById('disp').style.display='block'"

--- a/app/javascript/packs/question.js
+++ b/app/javascript/packs/question.js
@@ -1,4 +1,4 @@
-document.addEventListener("turbolinks:load", function(){
+document.addEventListener("DOMContentLoaded", function(){
   let answer = "";
   const q1_1 = document.getElementById('q1_1');
   const q1_2 = document.getElementById('q1_2');

--- a/app/javascript/packs/swiper.js
+++ b/app/javascript/packs/swiper.js
@@ -1,4 +1,4 @@
-document.addEventListener("turbolinks:load", function(){
+document.addEventListener("DOMContentLoaded", function(){
 const mySwiper = new Swiper('.swiper', {
   // Optional parameters
   loop: true,

--- a/app/javascript/packs/transform.js
+++ b/app/javascript/packs/transform.js
@@ -1,4 +1,4 @@
-document.addEventListener("turbolinks:load", function(){
+document.addEventListener("DOMContentLoaded", function(){
   const cards = document.getElementById('cards');
   const First = document.getElementsByClassName('First');
   const Second = document.getElementsByClassName('Second');

--- a/app/javascript/packs/twitter.js
+++ b/app/javascript/packs/twitter.js
@@ -1,5 +1,5 @@
 
-document.addEventListener("turbolinks:load", function(){ 
+document.addEventListener("DOMContentLoaded", function(){ 
   
   const tweet = document.getElementById('tweet');
   
@@ -21,9 +21,7 @@ document.addEventListener("turbolinks:load", function(){
   　    bty + '\n' +
   　    '#KIEETA ' + '#キエータ\n'
   　  ) + 
-  　  // '&url=https://mysterious-depths-28540.herokuapp.com/'      //本番環境
-  　 // '&url=https://shinrabansho.com/'                              //開発環境の参考
-  　  '&url=https://kieeta.com/'                                 //本番環境(独自ドメイン取得後)
+  　  '&url=https://kieeta.com/'
   　  ;
     tweet.href = tweetUrl;
     

--- a/app/javascript/packs/typing.js
+++ b/app/javascript/packs/typing.js
@@ -92,13 +92,13 @@ function typing2() {
 }
 
 
-$(document).on('turbolinks:load', function(){
+$(function(){
     if(document.URL.match(/introduction/)){
     typing1()
     }
 })
 
-$(document).on('turbolinks:load', function(){
+$(function(){
     if(document.URL.match(/results/)){
     typing2()
     }


### PR DESCRIPTION
turbolinksによりアニメーションがちらつくので無効化しました。
turbolinksの無効化によって、javascriptのdocument.addEventListener('turbolinks.load', function){...}が効かなくなるので、document.addEventListener('DOMContentLoaded', function){...}に変更しました。