### PR TITLE
[fix]url最後の/を削除

### DIFF
--- a/app/javascript/packs/twitter.js
+++ b/app/javascript/packs/twitter.js
@@ -21,7 +21,7 @@ document.addEventListener("DOMContentLoaded", function(){
   　    bty + '\n' +
   　    '#KIEETA ' + '#キエータ\n'
   　  ) + 
-  　  '&url=https://kieeta.com/'
+  　  '&url=https://kieeta.com'
   　  ;
     tweet.href = tweetUrl;
     


### PR DESCRIPTION
Twitterの拡散機能
スマホからツイートすると、「/」がついているせいでogpが上手く表示されない